### PR TITLE
Add a dependency on the "result" package

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -63,6 +63,8 @@
    (>= 0.9.8))
   (yojson
    (>= 2.0.2))
+  (result
+   (>= 1.5))
   ;; Documentation
   (odoc :with-doc)
   ;; Test/Dev dependencies

--- a/guardian.opam
+++ b/guardian.opam
@@ -31,6 +31,7 @@ depends: [
   "uri" {>= "4.2.0"}
   "uuidm" {>= "0.9.8"}
   "yojson" {>= "2.0.2"}
+  "result" {>= "1.5"}
   "odoc" {with-doc}
   "alcotest-lwt" {with-test}
 ]


### PR DESCRIPTION
This fixes a build error in switches where "result" is not installed, and makes it possible to build this project with dune package management.